### PR TITLE
adds ability to start rslsync with specific GID and UID

### DIFF
--- a/run_sync
+++ b/run_sync
@@ -7,4 +7,18 @@ if ! [ -f /mnt/sync/sync.conf ]; then
     cp /etc/sync.conf.default /mnt/sync/sync.conf;
 fi
 
-exec /usr/bin/rslsync --nodaemon $*
+USER_ID=${UID:-1001}
+GROUP_ID=${GID:-1001}
+
+echo "Starting with User $USER_ID:$GROUP_ID"
+usermod -G "" resilio
+deluser resilio
+groupdel resilio
+groupadd -g $GROUP_ID resilio
+useradd --shell /bin/bash -u $USER_ID -o -c "" -m resilio -g $GROUP_ID
+export HOME=/home/resilio
+
+chown -R $USER_ID:$GROUP_ID /mnt
+chmod -R 770 /mnt
+
+exec /bin/su - resilio -c "/usr/bin/rslsync --nodaemon $*"


### PR DESCRIPTION
fixes #12 

This will create a resilio group and user with the provided env variables "UID" and "GID". To be able to change the GID and UID after first run I implemented a brute force method wich will destroy the current resilio group and user and creates a new one on every start.
Maybe there is a more elegant way…, but its a start and adds the ability to run resilio via Docker as non root user