### PR TITLE
Multi-arch support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,22 @@
 # VERSION               0.1
 #
 
-FROM ubuntu
-MAINTAINER Resilio Inc. <support@resilio.com>
+ARG FROM_ARCH=amd64
+
+FROM alpine AS builder
+
+ARG VERSION=2.7.2
+ARG ARCH=x64
+ADD https://download-cdn.resilio.com/${VERSION}/linux-${ARCH}/resilio-sync_${ARCH}.tar.gz resilio-sync.tar.gz
+RUN tar zxvf resilio-sync.tar.gz
+
+
+FROM ${FROM_ARCH}/ubuntu
+
+LABEL maintainer="Resilio Inc. <support@resilio.com>"
 LABEL com.resilio.version="2.7.2"
 
-ADD https://download-cdn.resilio.com/2.7.2/linux-x64/resilio-sync_x64.tar.gz /tmp/sync.tgz
-RUN tar -xf /tmp/sync.tgz -C /usr/bin rslsync && rm -f /tmp/sync.tgz
-
+COPY --from=builder rslsync /usr/bin
 COPY sync.conf.default /etc/
 COPY run_sync /usr/bin/
 
@@ -20,7 +29,7 @@ EXPOSE 8888/tcp
 EXPOSE 55555/tcp
 
 # listening port
-EXPOSE 55555/udp  
+EXPOSE 55555/udp 
 
 # More info about ports used by Sync you can find here:
 # https://help.resilio.com/hc/en-us/articles/204754759-What-ports-and-protocols-are-used-by-Sync-

--- a/Multi-Arch-Builds-on-Docker-Hub.md
+++ b/Multi-Arch-Builds-on-Docker-Hub.md
@@ -1,0 +1,43 @@
+# Multi-arch builds on Docker Hub
+
+The [Custom build phase hooks](https://docs.docker.com/docker-hub/builds/advanced/#override-build-test-or-push-commands) build all variants for all platforms, e.g. `amd64` and `arm32v7`, on Docker Hub.
+
+More specifically, the hooks
+
+- Build the image variants in the `build` phase
+- Push all images in the `push` phase
+- Update the multi-arch manifest in the `post_push` phase
+
+The `post_push` hook generates and pushes the manifest which - simply put - is just a list of references to other images.
+
+```yaml
+# Manifest for resilio/sync:release-2.6.3 which points to the amd64 and arm32v7 images
+image: resilio/sync:release-2.6.3
+manifests:
+  - image: resilio/sync:release-2.6.3-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: resilio/sync:release-2.6.3-arm32v7
+    platform:
+      architecture: arm
+      os: linux
+      variant: v7
+```
+
+## Setting up Docker Hub Automated Builds
+
+The following Docker Hub configuration for Automated Builds results in the tags listed in the [README.md](./README.md).
+
+| Source Type | Source | Docker Tag          | Dockerfile location | Build Context |
+| ----------- | ------ | ------------------- | ------------------- | ------------- |
+| Branch      | master | latest              | Dockerfile          | /             |
+| Tag         | /.\*/  | release-{sourceref} | Dockerfile          | /             |
+
+The `master` branch creates the multi-arch `latest` image and its the platform specific `latest-*` variants.
+
+The tags are published as `release-*` images, e.g. the Git tag `2.6.3` creates the multi-arch `release-2.6.3` image and its platform specific `release-2.6.3-*` variants.
+
+## References
+
+For more details, see [Advanced options for Autobuild and Autotest](https://docs.docker.com/docker-hub/builds/advanced/).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-## Resilio Sync
+# Resilio Sync
 
-https://www.resilio.com
+<https://www.resilio.com>
 
 Sync uses peer-to-peer technology to provide fast, private file sharing for teams and individuals. By skipping the cloud, transfers can be significantly faster because files take the shortest path between devices. Sync does not store your information on servers in the cloud, avoiding cloud privacy concerns.
 
-### Usage
+## Usage
 
-```
+```bash
 # path to folder on the host to be mounted to container as Sync storage folder
 DATA_FOLDER=/path/to/data/folder/on/the/host
 mkdir -p $DATA_FOLDER
@@ -27,10 +27,12 @@ docker run -d --name Sync \
            --restart always \
            resilio/sync
 ```
+
 Note 1: we need to mount `/etc/localtime` from host OS to container to ensure container's time is synced with the host's time.
 
-Note 2: you can use our official Docker image `resilio/sync` hosted on https://hub.docker.com/u/resilio or build image manually:
-```
+Note 2: you can use our official Docker image `resilio/sync` hosted on <https://hub.docker.com/u/resilio> or build image manually:
+
+```bash
 git clone git@github.com:bt-sync/sync-docker.git
 cd sync-docker
 docker build -t resilio/sync .
@@ -44,25 +46,25 @@ If you need to run Sync under specific user inside your container - use `--user`
 
 Running Sync in docker container via [docker-compose](https://docs.docker.com/compose/) is described [here](https://github.com/bt-sync/sync-docker/tree/master/docker-compose).
 
-### Volumes
+## Volumes
 
-* `/mnt/sync` - folder inside the container that contains the [storage folder](https://help.resilio.com/hc/en-us/articles/206664690-Sync-Storage-folder), [configuration file](https://help.resilio.com/hc/en-us/articles/206178884) and default download folder
+- `/mnt/sync` - folder inside the container that contains the [storage folder](https://help.resilio.com/hc/en-us/articles/206664690-Sync-Storage-folder), [configuration file](https://help.resilio.com/hc/en-us/articles/206178884) and default download folder
 
-* `/etc/localtime` - file (symlink) that [configures](https://unix.stackexchange.com/questions/85925/how-can-i-examine-the-contents-of-etc-localtime) the system-wide timezone of the local system that is used by applications for presentation to the user
+- `/etc/localtime` - file (symlink) that [configures](https://unix.stackexchange.com/questions/85925/how-can-i-examine-the-contents-of-etc-localtime) the system-wide timezone of the local system that is used by applications for presentation to the user
 
-### Ports
+## Ports
 
-* `8888` - Webui port
-* `55555` - Listening port (both TCP and UDP) for Sync traffic (you can change it, but in this case change it in Sync [settings](https://help.resilio.com/hc/en-us/articles/204762669-Sync-Preferences) as well)
+- `8888` - Webui port
+- `55555` - Listening port (both TCP and UDP) for Sync traffic (you can change it, but in this case change it in Sync [settings](https://help.resilio.com/hc/en-us/articles/204762669-Sync-Preferences) as well)
 
 Find more info [here](https://help.resilio.com/hc/en-us/articles/204754759-What-ports-and-protocols-are-used-by-Sync-) about ports used by Sync.
 
-#### LAN access
+### LAN access
 
-If you do not want to limit the access to the webui - do not specify `localhost` address in `-p` parameter, 
+If you do not want to limit the access to the webui - do not specify `localhost` address in `-p` parameter,
 in this case every person in your LAN will be able to access web UI via `http://<your_ip_address>:<WEBUI_PORT>`:
 
-```
+```bash
 WEBUI_PORT=8888
 
 docker run -d --name Sync \
@@ -75,14 +77,14 @@ docker run -d --name Sync \
            resilio/sync
 ```
 
-You can also force web UI to work over https instead of http. To do this you need to add `force_https` parameter in 
+You can also force web UI to work over https instead of http. To do this you need to add `force_https` parameter in
 config file in `webui` section with `true` value. More info about config file parameters is [here](https://help.resilio.com/hc/en-us/articles/206178884-Running-Sync-in-configuration-mode).
 
-#### Extra directories
+### Extra directories
 
 If you need to mount extra directories, mount them in `/mnt/mounted_folders`:
 
-```
+```bash
 OTHER_DIR=/path/to/some/dir/on/host
 OTHER_DIR2=/path/to/some/another/dir/on/host
 
@@ -100,7 +102,7 @@ docker run -d --name Sync \
 
 Note: do not create directories at the root of `/mnt/mounted_folders` from the Sync web UI since they will not be mounted to the host. You need to mount those first as described above and then add them in Sync via web UI.
 
-### Miscellaneous
+## Miscellaneous
 
 - Additional info and various Sync guides can be found in our [help center](https://help.resilio.com)
 - If you have any questions left, please contact us via [support page](https://help.resilio.com/hc/en-us/requests/new?ticket_form_id=91563) or visit our forum at [https://forum.resilio.com](https://forum.resilio.com)

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Custom build script to build images for all supported architectures.
+#
+# Example for IMAGE_NAME: resilio/sync:release-2.6.3
+# Images built:
+# - resilio/sync:release-2.6.3-amd64
+# - resilio/sync:release-2.6.3-arm32v7
+
+for arch in amd64 arm32v7
+do
+  echo "Building $IMAGE_NAME-$arch"
+  docker build --build-arg FROM_ARCH=$arch --file $DOCKERFILE_PATH --tag $IMAGE_NAME-$arch .
+done

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "Pushing multi-arch manifest $IMAGE_NAME"
+
+# Use manifest-tool to create the manifest, given the experimental
+# "docker manifest" command isn't available yet on Docker Hub.
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v0.9.0/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+cat > manifest-generated.yaml << EOF
+image: $IMAGE_NAME
+manifests:
+  - image: $IMAGE_NAME-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: $IMAGE_NAME-arm32v7
+    platform:
+      architecture: arm
+      os: linux
+      variant: v7
+EOF
+
+./manifest-tool push from-spec manifest-generated.yaml

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Register qemu-*-static for all supported processors except the
+# current one, but also remove all registered binfmt_misc before
+docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Custom build script to push images for all supported architectures.
+#
+# Example for IMAGE_NAME: resilio/sync:release-2.6.3
+# Images pushed:
+# - resilio/sync:release-2.6.3-amd64
+# - resilio/sync:release-2.6.3-arm32v7
+
+for arch in amd64 arm32v7
+do
+  echo "Pushing $IMAGE_NAME-$arch"
+  docker push $IMAGE_NAME-$arch
+done


### PR DESCRIPTION
Added multi-arch support, e.g. to address bt-sync/sync-docker#25.

If there's anything missing or should be done differently, just let me know.